### PR TITLE
Adds support for changing the keyfile

### DIFF
--- a/elsabuilder/elsabuilder.py
+++ b/elsabuilder/elsabuilder.py
@@ -1,5 +1,6 @@
 import json
 import os
+import string
 import sys
 
 import click
@@ -27,7 +28,7 @@ def cli(debug):
 def frankenbuild(host, args):
     largs = list(args)
     dirs_to_upload = []
-    
+
     for i,arg in enumerate(largs):
         if '=' in arg:
             k,v = arg.split('=')
@@ -36,7 +37,11 @@ def frankenbuild(host, args):
                 largs[i] = '='.join([k, remote_dir])
                 dirs_to_upload.append(v)
 
-    run(largs, dirs_to_upload, host)
+    keyfile = (arg for arg in largs if arg.startswith('--keyfile')).next()
+    if keyfile:
+        run(largs, dirs_to_upload, host, string.split(keyfile, '=')[1])
+    else:
+        run(largs, dirs_to_upload, host)
 
 
 @cli.command()

--- a/elsabuilder/remote/fabfile.py
+++ b/elsabuilder/remote/fabfile.py
@@ -5,7 +5,6 @@ from fabric.contrib import files
 
 # floaty get centos-7-x86_64
 env.user = 'root'
-env.key_filename = '/Users/jayson.barley/.ssh/id_rsa-acceptance'
 
 # _run = run
 
@@ -34,17 +33,17 @@ def run_frankenbuild(args):
 
         run("tmux send-keys './frankenbuilder {}'".format(args))
         run('tmux send-keys ENTER')
-        
+
 @task
 def install_acceptance_tests():
     run('gem install beaker')
-    put('~/.ssh', '~/', mirror_local_mode=True)
+    put(env.key_filename, '~/.ssh')
     run('git clone git@github.com:puppetlabs/pe_acceptance_tests.git')
 
 
 @task
 def install_frankenbuilder():
-    put('~/.ssh', '~/', mirror_local_mode=True)
+    put(env.key_filename, '~/.ssh')
     run('git clone git@github.com:puppetlabs/frankenbuilder.git')
 
 
@@ -62,7 +61,7 @@ def install_rbenv():
 def install_ruby(version='2.4.2'):
     run('rbenv install -s {}'.format(version))
     run('rbenv global {}'.format(version))
-        
+
     run('gem install bundle')
 
 

--- a/elsabuilder/remote/frankenbuild.py
+++ b/elsabuilder/remote/frankenbuild.py
@@ -6,7 +6,9 @@ from fabric.contrib.project import rsync_project
 from sh import floaty
 
 
-def run(args, upload_dirs=[], host=None):
+def run(args, upload_dirs=[], host=None, keyfile='~/.ssh/id_rsa-acceptance'):
+    env.key_filename = keyfile
+    
     if not host:
         arch = 'centos-7-x86_64'
         res = floaty.get(arch)


### PR DESCRIPTION
This commit adds support for changing the keyfile used to connect to the
VMPooler boxes. Additionally, I updated the keyfile sync to only push up
the provided keyfile, and not the entire `.ssh` directory. Only problem
is, this makes it so that we cannot checkout github repos on the vm.